### PR TITLE
fixes whch make inchem py work with the different species files

### DIFF
--- a/inchempy/modules/inchem_import.py
+++ b/inchempy/modules/inchem_import.py
@@ -295,8 +295,7 @@ def import_all(filename):
     rates_in = rate_coeff(filename)   
     
     #Check the species import for blank values and remove
-    if species[0] == '':
-        species.pop(0)
+    species = [x for x in species if x != '']
         
     species.sort() #alphabetic
     

--- a/inchempy/modules/inchem_main.py
+++ b/inchempy/modules/inchem_main.py
@@ -833,11 +833,11 @@ def run_inchem(filename, particles, INCHEM_additional, custom, rel_humidity,
     '''
     Optional H2O2 and O3 deposition
     '''
-    if H2O2_dep == True and ("H2O2" in species):
+    if H2O2_dep == True:
         H2O2_rates, H2O2_reactions = H2O2_deposition()
         reactions_numba = reactions_numba + H2O2_reactions
         rate_numba = rate_numba + H2O2_rates
-    if O3_dep == True and ("O3" in species):
+    if O3_dep == True:
         O3_rates, O3_reactions = O3_deposition()
         reactions_numba = reactions_numba + O3_reactions
         rate_numba = rate_numba + O3_rates
@@ -1040,8 +1040,6 @@ def run_inchem(filename, particles, INCHEM_additional, custom, rel_humidity,
         
         if automatically_fix_undefined_species:
             undefined_dict = undefined_species_dict(summations_dict,density_dict,calc_dict)
-            if(len(undefined_dict) >0):
-                print(f'Warning {len(undefined_dict)} undefined species were assumed to have 0 concentrations:\n\t', [k for k in undefined_dict])
             density_dict.update(undefined_dict)
         
         sums_dict = {}
@@ -1052,8 +1050,6 @@ def run_inchem(filename, particles, INCHEM_additional, custom, rel_humidity,
         
         if automatically_fix_undefined_species:
             undefined_dict = undefined_species_dict(part_calc_dict,density_dict,calc_dict)
-            if(len(undefined_dict) >0):
-                print(f'Warning {len(undefined_dict)} undefined species were assumed to have 0 concentrations:\n\t', [k for k in undefined_dict])
             density_dict.update(undefined_dict)
 
         particle_dict = particle_calcs(part_calc_dict,density_dict)
@@ -1077,10 +1073,8 @@ def run_inchem(filename, particles, INCHEM_additional, custom, rel_humidity,
     reaction_rate_dict={}
     
     if automatically_fix_undefined_species:
-        full_dict={**J_dict,**calc_dict,**density_dict,**outdoor_dict,**surface_dict,**timed_dict}
+        full_dict={**J_dict,**density_dict,**outdoor_dict,**surface_dict,**timed_dict}
         undefined_dict = undefined_species_dict(reaction_compiled_dict,full_dict,calc_dict)
-        if(len(undefined_dict) >0):
-            print(f'Warning {len(undefined_dict)} undefined species were assumed to have 0 concentrations:\n\t', [k for k in undefined_dict])
         density_dict.update(undefined_dict)
 
     reaction_eval(reaction_rate_dict,reaction_number,J_dict,calc_dict,density_dict,\

--- a/inchempy/modules/initial_dictionaries.py
+++ b/inchempy/modules/initial_dictionaries.py
@@ -360,10 +360,37 @@ def timed_import(timed_inputs):
     return timed_reactions, emission_group
 
 
-def undefined_species_dict(compiled_code_dict, density_dict, calc_dict):
+def undefined_species_dict(compiled_code_dict, variables_dict, calc_dict):
+    '''
+    Identifies species in the compiled code segments which will not be
+    successfully resolved.
+    This can be used to add a placeholder for absent species to the
+    density dictionary (with 0 density).
+    This in turn cam allow the summations, particle calculations, or reaction
+    rates to be calculated despite a reduced model (without the complete MCM).
+
+    If a prerequisite of the compiled code is in neither of the 2 provided
+    dictionaries, it is returned as undefined.
+
+    inputs:
+        compiled_code_dict = a dictionary of compiled code segments, whose
+            variables will need to be defined.
+        variables_dict = a dictionary of variables which are already defined
+        calc_dict = a dictionary of other terms which are already defined
+
+    returns:
+        timed_reactions = a dictionary whose keys give any species which are
+            essential for the calculation, but are not included in either the
+            variables, or calculations, provided.
+            The values of the dictionary are 0, so that appending this to the
+            density would declare the species absent.
+    '''
     result = {}
     for code_block in compiled_code_dict.values():
         for species in code_block.co_names:
-            if (species not in density_dict and species not in calc_dict):
+            if (species not in variables_dict and species not in calc_dict):
                 result[species] = 0.0
+    if (len(result) > 0):
+        print(f'Warning {len(result)} undefined species were assumed to have 0 concentrations:\n\t',
+              [k for k in result])
     return result

--- a/inchempy/modules/initial_dictionaries.py
+++ b/inchempy/modules/initial_dictionaries.py
@@ -366,7 +366,7 @@ def undefined_species_dict(compiled_code_dict, variables_dict, calc_dict):
     successfully resolved.
     This can be used to add a placeholder for absent species to the
     density dictionary (with 0 density).
-    This in turn cam allow the summations, particle calculations, or reaction
+    This in turn can allow the summations, particle calculations, or reaction
     rates to be calculated despite a reduced model (without the complete MCM).
 
     If a prerequisite of the compiled code is in neither of the 2 provided

--- a/inchempy/modules/initial_dictionaries.py
+++ b/inchempy/modules/initial_dictionaries.py
@@ -358,3 +358,12 @@ def timed_import(timed_inputs):
         for species, emission in species_emission.items():
             timed_reactions.append([f"timed_{i}*({emission[0][2]})",f"= {species}"])
     return timed_reactions, emission_group
+
+
+def undefined_species_dict(compiled_code_dict, density_dict, calc_dict):
+    result = {}
+    for code_block in compiled_code_dict.values():
+        for species in code_block.co_names:
+            if (species not in density_dict and species not in calc_dict):
+                result[species] = 0.0
+    return result

--- a/multiroom_model/inchem.py
+++ b/multiroom_model/inchem.py
@@ -47,7 +47,8 @@ class InChemPyInstance:
                  reactions_output: bool = True,
                  output_graph: bool = True,
                  output_species: Optional[List[str]] = None,
-                 settings_file: str = __file__):
+                 settings_file: str = __file__,
+                 automatically_fix_undefined_species = False):
         """
         @brief Initialize the InChemPySettings class with simulation parameters.
 
@@ -174,6 +175,8 @@ class InChemPyInstance:
 
         self.settings_file: Optional[str] = settings_file
 
+        self.automatically_fix_undefined_species = automatically_fix_undefined_species
+
     def run(self) -> Any:
         return run_inchem(self.filename, self.particles, self.INCHEM_additional, self.custom, self.rel_humidity,
                           self.M, self.const_dict, self.ACRate, self.diurnal, self.city, self.date, self.lat,
@@ -184,4 +187,5 @@ class InChemPyInstance:
                           self.reactions_output, self.H2O2_dep, self.O3_dep, self.adults,
                           self.children, self.surface_area, self.settings_file, self.temperatures, self.spline,
                           self.custom_filename,
-                          self.constrained_file)
+                          self.constrained_file,
+                          self.automatically_fix_undefined_species)

--- a/multiroom_model_tests/test_inchem_py.py
+++ b/multiroom_model_tests/test_inchem_py.py
@@ -1,15 +1,100 @@
 import unittest
 from multiroom_model.inchem import InChemPyInstance
-from inchempy import modules
+
 
 class TestInChemPy(unittest.TestCase):
     def test_inchempy_runs(self):
         inchem_py_instance: InChemPyInstance = InChemPyInstance(
+            particles=False,
+            INCHEM_additional=False,
             seconds_to_integrate=180,
             output_graph=False)
 
         inchem_py_instance.run()
 
+    def test_inchempy_runs_with_chem_mech_set(self):
+        inchem_py_instance: InChemPyInstance = InChemPyInstance(
+            filename="chem_mech/mcm_v331.fac",
+            particles=False,
+            INCHEM_additional=False,
+            seconds_to_integrate=180,
+            output_graph=False)
+
+        inchem_py_instance.run()
+
+    def test_inchempy_runs_with_escs_v1_set(self):
+        inchem_py_instance: InChemPyInstance = InChemPyInstance(
+            filename="chem_mech/escs_v1.fac",
+            particles=False,
+            INCHEM_additional=False,
+            seconds_to_integrate=180,
+            output_graph=False)
+
+        inchem_py_instance.run()
+
+    def test_inchempy_runs_with_rcs_2023_set(self):
+        inchem_py_instance: InChemPyInstance = InChemPyInstance(
+            filename="chem_mech/rcs_2023.fac",
+            particles=False,
+            INCHEM_additional=False,
+            seconds_to_integrate=180,
+            output_graph=False)
+
+        inchem_py_instance.run()
+
+    def test_inchempy_runs_with_mcm_subset_set(self):
+        inchem_py_instance: InChemPyInstance = InChemPyInstance(
+            filename="chem_mech/mcm_subset.fac",
+            particles=False,
+            INCHEM_additional=False,
+            seconds_to_integrate=180,
+            output_graph=False)
+
+        inchem_py_instance.run()
+
+    
+    def test_inchempy_runs_with_chem_mech_set_and_additions(self):
+        inchem_py_instance: InChemPyInstance = InChemPyInstance(
+            filename="chem_mech/mcm_v331.fac",
+            particles=True,
+            INCHEM_additional=True,
+            seconds_to_integrate=180,
+            output_graph=False)
+
+        inchem_py_instance.run()
+
+    def test_inchempy_runs_with_escs_v1_set_and_additions(self):
+        inchem_py_instance: InChemPyInstance = InChemPyInstance(
+            filename="chem_mech/escs_v1.fac",
+            particles=True,
+            INCHEM_additional=False,
+            seconds_to_integrate=180,
+            output_graph=False,
+            automatically_fix_undefined_species=True)
+
+        inchem_py_instance.run()
+
+    def test_inchempy_runs_with_rcs_2023_set_and_additions(self):
+        inchem_py_instance: InChemPyInstance = InChemPyInstance(
+            filename="chem_mech/rcs_2023.fac",
+            particles=True,
+            INCHEM_additional=True,
+            seconds_to_integrate=180,
+            output_graph=False,
+            automatically_fix_undefined_species=True)
+
+        inchem_py_instance.run()
+
+    def test_inchempy_runs_with_mcm_subset_set_and_additions(self):
+        inchem_py_instance: InChemPyInstance = InChemPyInstance(
+            filename="chem_mech/mcm_subset.fac",
+            particles=True,
+            INCHEM_additional=True,
+            seconds_to_integrate=180,
+            output_graph=False,
+            automatically_fix_undefined_species=True)
+
+        inchem_py_instance.run()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There were cases where we were using a subset of the chemical species, these didn't work.
This is a series of fixes to solve that:
+ removed the assumption that any blank species (which needed removing) would be item 0
+ Added a method to detect undefined species in compiled code by looking for `co_names` which couldn't be resolved in the dictionaries
+ Added an optional functionality to resolve any undefined species by setting their concentrations to 0
+ Added unit tests to test all the different files and setting types